### PR TITLE
Add health check endpoint

### DIFF
--- a/bot/health.py
+++ b/bot/health.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from aiohttp import web
+
+
+async def ok(request: web.Request) -> web.Response:
+    """Return status response."""
+    return web.json_response({"status": "ok"})
+
+
+def create_app() -> web.Application:
+    """Create aiohttp application with health route."""
+    app = web.Application()
+    app.router.add_get("/health", ok)
+    return app


### PR DESCRIPTION
## Summary
- add aiohttp-based health check app with `/health` route

## Testing
- `ruff check bot/health.py`
- `black --check bot/health.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891da641c30832dbf22b95a394eab33