### PR TITLE
Add healthcheck for bot service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,9 @@ services:
     volumes:
       - ./output:/app/output
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s


### PR DESCRIPTION
## Summary
- add curl-based health check to bot service in docker-compose

## Testing
- `pre-commit run --files docker-compose.yml`
- `pytest`
- `docker ps` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_6891de5c937c832d8c35aca0c6544b5a